### PR TITLE
useHtml5routing

### DIFF
--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -22,6 +22,8 @@ angular.module('myApp.routeConfig', ['ngRoute'])
                 templateUrl: '/assets/partials/create.html'
             })
             .otherwise({redirectTo: '/'})
+    .config ($locationProvider) ->
+        $locationProvider.html5Mode(true)
 
 @commonModule = angular.module('myApp.common', [])
 @controllersModule = angular.module('myApp.controllers', [])


### PR DESCRIPTION
Add AngularJS configuration so that, whenever it is allowed by browsers, the # (hashtag) in URL is avoided, without losing capability of client-side routing.
